### PR TITLE
Various improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<script src='https://www.desmos.com/api/v1.3/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6'></script>
+<script src='https://www.desmos.com/api/v1.6/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6'></script>
 <html lang='en'>
    <head>
       <title>Desmos | Graphing Calculator</title>
@@ -7,13 +7,13 @@
    <div id='calculator' style='width: 100%; height: 100%;'></div>
    <script>
         var elt = document.getElementById('calculator');
-        var calculator = Desmos.GraphingCalculator(elt, {showGrid: true, showYAxis: true, showXAxis: true});
+        var calculator = Desmos.GraphingCalculator(elt);
 
-        var inner = elt.getElementsByClassName("dcg-graph-outer")[0]; // The part of the screen with a visible grid
+        var inner = elt.getElementsByClassName('dcg-graph-outer')[0]; // The part of the screen with a visible grid
         var defaultState;
         var latex;
-        var width;
         var height;
+        var width;
         var download_images;
         var total_frames;
 
@@ -22,64 +22,92 @@
             xhr.open('GET', `http://127.0.0.1:5000/init`);
             xhr.send();
         }, 1000);
+
         xhr.onload = () => { // Setup when backend connects successfully
             clearInterval(interval);
             latex = JSON.parse(xhr.response);
-            width = latex.width;
             height = latex.height;
+            width = latex.width;
             total_frames = latex.total_frames;
             download_images = latex.download_images;
-            calculator.setExpression({ id: 'frame', latex: 'f=0', color: '#2464b4', sliderBounds: { step: 1, max: total_frames, min: 0 } });
-            var f = calculator.HelperExpression({ latex: 'f' });
-            f.observe('numericValue', function() {
-                if (Number.isNaN(f.numericValue) || f.numericValue <= 0) return;
-                f.unobserve('numericValue');
-                setTimeout(() => renderFrame(--f.numericValue), 3000); // Wait for additional keystrokes
-                });
 
-            defaultState = calculator.getState(); // setBlank erases everything, we use a state instead to keep the f=0 at the top
+            var lastFrame = parseInt(sessionStorage.getItem('lastFrame')) || 0; // Get frame from page refresh
+            sessionStorage.removeItem('lastFrame');
+
+            calculator.setExpression({ id: 'frame', latex: `f=${lastFrame}`, color: '#2464b4', sliderBounds: { step: 1, max: total_frames, min: 0 } });
+            calculator.setExpression({ id: 'lines', latex: 'l=0', color: '#2464b4' });
+            if (lastFrame != 0) { // This is a refresh
+                const viewport = JSON.parse(sessionStorage.getItem('viewport'));
+                sessionStorage.removeItem('viewport');
+                calculator.setViewport([viewport.xmin, viewport.xmax, viewport.ymin, viewport.ymax]);
+                renderFrame(lastFrame);
+            } else { // This is the first time loading the page
+                var f = calculator.HelperExpression({ latex: 'f' });
+                f.observe('numericValue', () => {
+                    if (Number.isNaN(f.numericValue) || f.numericValue <= 0) return;
+                    f.unobserve('numericValue');
+                    setTimeout(() => renderFrame(--f.numericValue), 3000); // Wait for additional keystrokes
+                });
+            }
+            defaultState = calculator.getState(); // setBlank resets graph settings, this doesn't
+            defaultState.graph.showGrid = defaultState.graph.showXAxis = defaultState.graph.showYAxis = latex.show_grid;
         }
 
         var loaded_frames = 0; // All frames loaded from backend so far
         var old_frames = 0; // Frames rendered prior to last backend request
         function renderFrame(frame) {
             if (frame >= total_frames) return; // Animation finished
-            if (frame >= loaded_frames) { // No more loaded frames, request more
+            if (loaded_frames == 0) { // Load a batch of frames
                 xhr = new XMLHttpRequest();
                 xhr.open('GET', `http://127.0.0.1:5000/?frame=${frame}`);
                 xhr.send();
                 xhr.onload = () => {
                     latex = JSON.parse(xhr.response);
                     if (latex.result === null) return;
-                    loaded_frames += latex.number_of_frames;
+                    loaded_frames = frame + latex.number_of_frames;
                     old_frames = frame;
                     renderFrame(frame);
                 }
             } else { // Render the next frame
                 const viewport = calculator.getState().graph.viewport;
+                var start = Date.now();
                 calculator.setState(defaultState);
                 calculator.setExpression( { id: 'frame', latex: 'f=' + (frame + 1) } );
+                calculator.setExpression( { id: 'lines', latex: 'l=' + latex.result[frame - old_frames].length});
+                console.log('Lines for frame ' + (frame + 1) + ': ' + latex.result[frame - old_frames].length);
                 calculator.setViewport([viewport.xmin, viewport.xmax, viewport.ymin, viewport.ymax]); // setState resets the viewport, set it back to what it was
-                calculator.setExpressions(latex.result[frame - old_frames]);
+                console.log('adding ' + (Date.now() - start) / 1000);
+                setTimeout(() => {
+                    calculator.setExpressions(latex.result[frame - old_frames]);
+                    console.log('drawing ' + (Date.now() - start) / 1000);
 
-                const params = {
-                    mode: 'stretch',
-                    mathBounds: { left: 0, bottom: 0, right: width, top: height },
-                    width: width,
-                    height: height
-                }
-                calculator.asyncScreenshot(params, screenshot => handleScreenshot(screenshot, ++frame)); // Waits for frame to render, takes a screenshot and runs handleScreenshot
+                    const params = {
+                        mode: 'stretch',
+                        mathBounds: { left: 0, bottom: 0, right: width, top: height },
+                        width: width,
+                        height: height,
+                        targetPixelRatio: 1
+                    }
+                    calculator.asyncScreenshot(params, screenshot => handleScreenshot(screenshot, start, ++frame)); // Waits for frame to render, takes a screenshot and runs handleScreenshot
+                }, 100); // Slight delay to allow the list to update
             }
         }
 
         const imgcont = document.createElement('a');
         document.body.appendChild(imgcont);
-        function handleScreenshot(screenshot, frame) {
+        async function handleScreenshot(screenshot, start, frame) {
+            console.log('done ' + (Date.now() - start) / 1000);
             imgcont.href = screenshot;
             imgcont.download = 'frame-' + String(frame).padStart(5, '0');
             imgcont.innerHTML = `<img src= ${screenshot}>`;
             if (download_images) imgcont.click();
-            setTimeout(() => renderFrame(frame), 150);
+
+            // Reloading the page every so often seems to reduce random slowdowns
+            if (frame >= loaded_frames) {
+                sessionStorage.setItem('lastFrame', frame);
+                sessionStorage.setItem('viewport', JSON.stringify(calculator.getState().graph.viewport));
+                location.reload();
+            } else renderFrame(frame);
         }
    </script>
 </html>


### PR DESCRIPTION
- Multiprocessing on the backend, should be significantly faster on modern hardware
- Automatically refresh the page when making a new request to the backend, hopefully this will reduce the random slowdowns that occur when rendering for extended periods
- Better edge detection, the thresholds are determined automatically based on the median color of the image
- Optional L2gradient for edge detection, detects less edges and speeds up the rendering significantly because of this, it is still quite accurate
- Added a duration to the message printed when the backend is finished processing images
- Added comments to the settings
- Added a setting to toggle the grid on or off when the image has started rendering

TODO:
- [ ] Update the readme with the new settings, I cant be bothered to do this though.