### PR TITLE
Will rename ordered files

### DIFF
--- a/frames.py
+++ b/frames.py
@@ -1,0 +1,13 @@
+import os
+
+dir = os.path.dirname(__file__)
+number = 1
+for filename in os.listdir("frames")[::-1]:
+    path = os.path.join(dir, "frames", filename)
+    if not filename.endswith(".png"):
+        os.remove(path)
+        print("Removed {}".format(filename))
+    else:
+        os.rename(path, os.path.join(dir, "frames", f"frame{str(number)}.png"))
+        print("Renamed {} to frame{}.png".format(filename, number))
+        number += 1


### PR DESCRIPTION
In certain scenarios, like if splitting a GIF into its PNG images, it will be ordered but be named weirdly. Rather than manually changing like 300, hopefully this will change any PNG file to the desired syntax. You can upload any random PNG file you want without renaming them and they will be summarily renamed.