### PR TITLE
improving rendering performance

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -129,6 +129,7 @@ def index():
     if frame >= len(os.listdir(FRAME_DIR)):
         return {'result': None}
 
+    """
     block = []
     if not DYNAMIC_BLOCK:
         number_of_frames = min(frame + BLOCK_SIZE, len(os.listdir(FRAME_DIR))) - frame
@@ -146,6 +147,8 @@ def index():
             block.append(frame_latex[i])
             i += 1
     return json.dumps({'result': block, 'number_of_frames': number_of_frames}) # Number_of_frames is the number of newly loaded frames, not the total frames
+    """
+    return json.dumps({'result': frame_latex[frame] })
 
 
 @app.route('/init')

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
 
                     await finishRender();
 
-                    if (response.length > 3000) { // a cooldown because this is a big file
+                    if (response.length >= 3000) { // a cooldown because this is a big file
                         await sleep(5000);
                     }
                     

--- a/index.html
+++ b/index.html
@@ -8,19 +8,29 @@
    <script>
         var elt = document.getElementById('calculator');
         var calculator = Desmos.GraphingCalculator(elt);
+        var hiddenGraph;
     
-        function changeGraph(key, latex, frame) {
-            calculator.setExpression( { id: 'frame', latex: 'f=' + (frame + 1) } );
-            while (key > 0) {
-                calculator.removeExpression({ id: 'expr-' + key });
-                key--;
-            }
+        function sleep(milliseconds) {
+            return new Promise(r => setTimeout(r, milliseconds));
+        }
+
+        async function changeGraph(latex) {
+            //console.log(latex);
+
+            var default_expressions = hiddenGraph.expressions.list.slice();
+
             for (var expr of latex) {
-                console.log(expr);
-                key++;
-                calculator.setExpression({ id: 'expr-' + key, latex: expr.latex, color: expr.color });
+                hiddenGraph.expressions.list.push({
+                    color: expr.color,
+                    id: expr.id,
+                    latex: expr.latex,
+                    type: "expression"
+                });
             }
-            return key;
+
+            calculator.setState( hiddenGraph, {'allowUndo': false} );
+            hiddenGraph.expressions.list = default_expressions;
+            await sleep(5000);
         }
 
         xhr = new XMLHttpRequest();
@@ -36,9 +46,20 @@
             var width = latex.width;
             var total_frames = latex.total_frames;
 
+            calculator.setMathBounds({
+                left: 0,
+                right: width,
+                bottom: 0,
+                top: height
+            });
+
             var lastFrame = parseInt(sessionStorage.getItem('lastFrame')) || 0;
 
             calculator.setExpression({ id: 'frame', latex: `f=0`, color: '#2464b4', sliderBounds: { step: 1, max: total_frames, min: 0 } });
+
+            // This is used to set expressions off screen
+            hiddenGraph = calculator.getState();
+            
             if (lastFrame != 0) { // This is a refresh
                 const viewport = JSON.parse(sessionStorage.getItem('viewport'));
                 sessionStorage.removeItem('viewport');
@@ -54,33 +75,46 @@
             }
         }
    
-        function renderFrame(frame) {
-            var key = 0;
-            var top = 0;
-            var bottom = 0;
-
+        async function renderFrame(frame) {
             var latex;
-   
-            const interval = setInterval(function() {
-                if (frame < top) {
-                    key = changeGraph(key, latex.result[frame - bottom], frame);
-                    frame++;
-                } else {
-                    xhr = new XMLHttpRequest();
-                    xhr.open("GET", `http://127.0.0.1:5000/?frame=${frame}`);
-                    xhr.send();
-                    xhr.onload = function(e) {
-                        latex = JSON.parse(xhr.response);
-                        if (latex.result === null)
-                            clearInterval(interval);
-                        console.log(latex.result[0])
-                        bottom = frame;
-                        top += latex.number_of_frames;
-                    }
-                }
+            
+            const requestData = (frame) => {
+            
+                return new Promise((resolve, reject) => {
 
-            }, 1000);
-       }
+                    xhr = new XMLHttpRequest();
+                    xhr.open('GET', `http://127.0.0.1:5000/?frame=${frame}`);
+                    xhr.send();
+                    xhr.onload = () => {
+                        latex = JSON.parse(xhr.response);
+
+                        if (latex.result === null){
+                            reject(`frame: ${frame} could not be rendered.`);
+                        } else {
+                            resolve(latex.result);
+                        }
+                    }
+                });
+            }
+
+            try { // Render each frame
+                var response = await requestData(frame);
+                while (response) {
+                    hiddenGraph.expressions.list[0].latex = "f=" + (frame + 1);
+
+                    // console.log('Lines for frame ' + (frame + 1) + ': ' + response.length);
+
+                    await changeGraph(response);
+                    
+                    frame++;
+                    response = await requestData(frame);
+                }
+            }
+            catch (err) {
+                console.log(err);
+            }
+        }
+
    
    </script>
 </html>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,10 @@
 
             calculator.setState( hiddenGraph, {'allowUndo': false} );
             hiddenGraph.expressions.list = default_expressions;
-            await sleep(5000);
+
+            if (latex.length < 3000) {
+                await sleep(5000);
+            }
         }
 
         xhr = new XMLHttpRequest();
@@ -105,6 +108,20 @@
                     // console.log('Lines for frame ' + (frame + 1) + ': ' + response.length);
 
                     await changeGraph(response);
+
+                    function finishRender() {
+                        return new Promise(resolve => {
+                            calculator.asyncScreenshot(screenshot => {
+                                resolve('render has finished');
+                            });
+                        });
+                    }
+
+                    await finishRender();
+
+                    if (response.length > 3000) { // a cooldown because this is a big file
+                        await sleep(5000);
+                    }
                     
                     frame++;
                     response = await requestData(frame);

--- a/quick.html
+++ b/quick.html
@@ -149,7 +149,7 @@
                     await finishRender();
 
                     // this delay happens after the frame is rendered
-                    if (response.length > 3000) { // a cooldown because this is a big file
+                    if (response.length >= 3000) { // a cooldown because this is a big file
                         await sleep(5000);
                     }
 

--- a/quick.html
+++ b/quick.html
@@ -11,11 +11,35 @@
 
         var inner = elt.getElementsByClassName('dcg-graph-outer')[0]; // The part of the screen with a visible grid
         var defaultState;
+        var hiddenGraph;
         var latex;
         var height;
         var width;
         var download_images;
         var total_frames;
+
+        function sleep(milliseconds) {
+            return new Promise(r => setTimeout(r, milliseconds));
+        }
+
+        async function changeGraph(latex) {
+            //console.log(latex);
+
+            var default_expressions = hiddenGraph.expressions.list.slice();
+
+            for (var expr of latex) {
+                hiddenGraph.expressions.list.push({
+                    color: expr.color,
+                    id: expr.id,
+                    latex: expr.latex,
+                    type: "expression"
+                })
+            }
+
+            calculator.setState( hiddenGraph, {'allowUndo': false} );
+            hiddenGraph.expressions.list = default_expressions;
+            await sleep(5000);
+        }
 
         xhr = new XMLHttpRequest();
         const interval = setInterval(() => { // Attempt backend connection
@@ -34,8 +58,25 @@
             var lastFrame = parseInt(sessionStorage.getItem('lastFrame')) || 0; // Get frame from page refresh
             sessionStorage.removeItem('lastFrame');
 
+            calculator.updateSettings({
+                showGrid: latex.show_grid,
+                showXAxis: latex.show_grid,
+                showYAxis: latex.show_grid
+            });
+
+            calculator.setMathBounds({
+                left: 0,
+                right: width,
+                bottom: 0,
+                top: height
+            });
+
             calculator.setExpression({ id: 'frame', latex: `f=${lastFrame}`, color: '#2464b4', sliderBounds: { step: 1, max: total_frames, min: 0 } });
             calculator.setExpression({ id: 'lines', latex: 'l=0', color: '#2464b4' });
+
+            // This is used to set expressions off screen
+            hiddenGraph = calculator.getState();
+            
             if (lastFrame != 0) { // This is a refresh
                 const viewport = JSON.parse(sessionStorage.getItem('viewport'));
                 sessionStorage.removeItem('viewport');
@@ -53,33 +94,36 @@
             defaultState.graph.showGrid = defaultState.graph.showXAxis = defaultState.graph.showYAxis = latex.show_grid;
         }
 
-        var loaded_frames = 0; // All frames loaded from backend so far
-        var old_frames = 0; // Frames rendered prior to last backend request
-        function renderFrame(frame) {
-            if (frame >= total_frames) return; // Animation finished
-            if (loaded_frames == 0) { // Load a batch of frames
-                xhr = new XMLHttpRequest();
-                xhr.open('GET', `http://127.0.0.1:5000/?frame=${frame}`);
-                xhr.send();
-                xhr.onload = () => {
-                    latex = JSON.parse(xhr.response);
-                    if (latex.result === null) return;
-                    loaded_frames = frame + latex.number_of_frames;
-                    old_frames = frame;
-                    renderFrame(frame);
-                }
-            } else { // Render the next frame
-                const viewport = calculator.getState().graph.viewport;
-                var start = Date.now();
-                calculator.setState(defaultState);
-                calculator.setExpression( { id: 'frame', latex: 'f=' + (frame + 1) } );
-                calculator.setExpression( { id: 'lines', latex: 'l=' + latex.result[frame - old_frames].length});
-                console.log('Lines for frame ' + (frame + 1) + ': ' + latex.result[frame - old_frames].length);
-                calculator.setViewport([viewport.xmin, viewport.xmax, viewport.ymin, viewport.ymax]); // setState resets the viewport, set it back to what it was
-                console.log('adding ' + (Date.now() - start) / 1000);
-                setTimeout(() => {
-                    calculator.setExpressions(latex.result[frame - old_frames]);
-                    console.log('drawing ' + (Date.now() - start) / 1000);
+        async function renderFrame(frame) {
+            
+            const requestData = (frame) => {
+            
+                return new Promise((resolve, reject) => {
+
+                    xhr = new XMLHttpRequest();
+                    xhr.open('GET', `http://127.0.0.1:5000/?frame=${frame}`);
+                    xhr.send();
+                    xhr.onload = () => {
+                        latex = JSON.parse(xhr.response);
+
+                        if (latex.result === null){
+                            reject(`frame: ${frame} could not be rendered.`);
+                        } else {
+                            resolve(latex.result);
+                        }
+                    }
+                });
+            }
+
+            try { // Render each frame
+                var response = await requestData(frame);
+                while (response) {
+                    hiddenGraph.expressions.list[0].latex = "f=" + (frame + 1);
+                    hiddenGraph.expressions.list[1].latex = "l=" + response.length;
+
+                    // console.log('Lines for frame ' + (frame + 1) + ': ' + response.length);
+
+                    await changeGraph(response);
 
                     const params = {
                         mode: 'stretch',
@@ -88,26 +132,31 @@
                         height: height,
                         targetPixelRatio: 1
                     }
-                    calculator.asyncScreenshot(params, screenshot => handleScreenshot(screenshot, start, ++frame)); // Waits for frame to render, takes a screenshot and runs handleScreenshot
-                }, 100); // Slight delay to allow the list to update
+                    
+                    frame++;
+                    calculator.asyncScreenshot(params, screenshot => handleScreenshot(screenshot, frame)); // Waits for frame to render, takes a screenshot and runs handleScreenshot
+                    response = await requestData(frame);
+                }
+            }
+            catch (err) {
+                console.log(err);
             }
         }
 
         const imgcont = document.createElement('a');
         document.body.appendChild(imgcont);
-        async function handleScreenshot(screenshot, start, frame) {
-            console.log('done ' + (Date.now() - start) / 1000);
+        async function handleScreenshot(screenshot, frame) {
             imgcont.href = screenshot;
             imgcont.download = 'frame-' + String(frame).padStart(5, '0');
             imgcont.innerHTML = `<img src= ${screenshot}>`;
             if (download_images) imgcont.click();
 
             // Reloading the page every so often seems to reduce random slowdowns
-            if (frame >= loaded_frames) {
-                sessionStorage.setItem('lastFrame', frame);
+            if (frame % 20 === 0) { // run every 20 frames
+                sessionStorage.setItem('lastFrame', frame +1);
                 sessionStorage.setItem('viewport', JSON.stringify(calculator.getState().graph.viewport));
                 location.reload();
-            } else renderFrame(frame);
+            }
         }
    </script>
 </html>

--- a/quick.html
+++ b/quick.html
@@ -38,7 +38,10 @@
 
             calculator.setState( hiddenGraph, {'allowUndo': false} );
             hiddenGraph.expressions.list = default_expressions;
-            await sleep(5000);
+
+            if (latex.length < 3000) {
+                await sleep(5000);
+            }
         }
 
         xhr = new XMLHttpRequest();
@@ -133,8 +136,24 @@
                         targetPixelRatio: 1
                     }
                     
+                    function finishRender() {
+                        return new Promise(resolve => {
+                             // Waits for frame to render, takes a screenshot and runs handleScreenshot
+                            calculator.asyncScreenshot(params, screenshot => {
+                                handleScreenshot(screenshot, frame +1);
+                                resolve('render has finished');
+                            });
+                        });
+                    }
+
+                    await finishRender();
+
+                    // this delay happens after the frame is rendered
+                    if (response.length > 3000) { // a cooldown because this is a big file
+                        await sleep(5000);
+                    }
+
                     frame++;
-                    calculator.asyncScreenshot(params, screenshot => handleScreenshot(screenshot, frame)); // Waits for frame to render, takes a screenshot and runs handleScreenshot
                     response = await requestData(frame);
                 }
             }
@@ -153,7 +172,7 @@
 
             // Reloading the page every so often seems to reduce random slowdowns
             if (frame % 20 === 0) { // run every 20 frames
-                sessionStorage.setItem('lastFrame', frame +1);
+                sessionStorage.setItem('lastFrame', frame);
                 sessionStorage.setItem('viewport', JSON.stringify(calculator.getState().graph.viewport));
                 location.reload();
             }


### PR DESCRIPTION
It looks like dynamic blocks and your loops were causing some memory issues which were making my browser crash.

quick.html uses a recursive function to render frames. It will create a new function on top of the next function on every iteration and so all the previously defined variables will still be in memory until the loop ends.

The setInterval() in index.html is not a delay between functions, it will try to loop every second.
Which is not good if you want to set a time limit between each request for the desmos api and it might also overload your browser
with tasks if it's struggling to keep up.

**Changes**

- made the script promise based

- added a 5 second delay between renders to set a rate limit on requests

- changed the logic for rendering frames

- dropping support for dynamic blocks


To render the graph I'm changing the values returned from calculator.getState() which is just a dictionary, then I'm adding it to setState()

I noticed it's faster than rendering with calculator.setExpressions(), probably because it's not actually rendered when we make the changes.

You can render the frames faster than this, though 600 frames/hour outta be enough for anybody.

and unfortunately I didn't like dynamic blocks which are very inefficient, Without the graphs , your script seemed to use 1-2 gb of ram. With my script it drops down to 100 - 200 mb (without the graphs).

I also ran my script without delays to stress test the connection, and I had no errors so I don't think dynamic blocks is useful. I added a pretty good delay, but if you still want it then I suggest we use a 1 block size just for quick.html

I also kept the refresh that was already in quick.html but I don't think it's needed you can compare it with index.html which doesn't have it.
