### PR TITLE
Enhancements for downloaded images

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -24,6 +24,7 @@ CORS(app)
 FRAME_DIR = 'frames' # The folder where the frames are stored relative to this file
 FILE_EXT = 'png' # Extension for frame files
 COLOUR = '#2464b4' # Hex value of colour for graph output	
+SCREENSHOT_SIZE = [ None, None ] # [width, height] for downloaded images
 
 BILATERAL_FILTER = False # Reduce number of lines with bilateral filter
 DOWNLOAD_IMAGES = False # Download each rendered frame automatically (works best in firefox)
@@ -48,6 +49,7 @@ def help():
     print('\t-l\t\tReduce number of lines with L2 gradient for quicker renders')
     print('\t-g\t\tHide the grid in the background of the graph\n')
     print('\t--yes\t\tAgree to EULA without input prompt')
+    print('\t--size <widthxheight>\tDimensions for downloaded images (e.g. 3840x2160)')
 
 
 def get_contours(filename, nudge = .33):
@@ -127,13 +129,13 @@ def index():
 @app.route("/calculator")
 def client():
     return render_template('index.html', api_key='dcb31709b452b1cf9dc26972add0fda6', # Development-only API_key. See https://www.desmos.com/api/v1.8/docs/index.html#document-api-keys
-            height=height.value, width=width.value, total_frames=len(os.listdir(FRAME_DIR)), download_images=DOWNLOAD_IMAGES, show_grid=SHOW_GRID)
+            height=height.value, width=width.value, total_frames=len(os.listdir(FRAME_DIR)), download_images=DOWNLOAD_IMAGES, show_grid=SHOW_GRID, screenshot_size=SCREENSHOT_SIZE)
 
 
 if __name__ == '__main__':
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "hf:e:c:bdlg", ['static', 'block=', 'maxpblock=', 'yes'])
+        opts, args = getopt.getopt(sys.argv[1:], "hf:e:c:bdlg", ['static', 'block=', 'maxpblock=', 'yes', 'size='])
 
     except getopt.GetoptError:
         print('Error: Invalid argument(s)\n')
@@ -163,9 +165,15 @@ if __name__ == '__main__':
                 SHOW_GRID = False
             elif opt == '--yes':
                 eula = 'y'
+            elif opt == '--size':
+                SCREENSHOT_SIZE = [ int(n) for n in arg.split('x', maxsplit=1) ]
+
+                if len(SCREENSHOT_SIZE) != 2:
+                    raise ValueError
+                
         frame_latex =  range(len(os.listdir(FRAME_DIR)))
 
-    except TypeError:
+    except (TypeError, ValueError):
         print('Error: Invalid argument(s)\n')
         help()
         sys.exit(2)

--- a/backend.py
+++ b/backend.py
@@ -25,6 +25,7 @@ FRAME_DIR = 'frames' # The folder where the frames are stored relative to this f
 FILE_EXT = 'png' # Extension for frame files
 COLOUR = '#2464b4' # Hex value of colour for graph output	
 SCREENSHOT_SIZE = [ None, None ] # [width, height] for downloaded images
+SCREENSHOT_FORMAT = 'png' # Format to use when downloading images
 
 BILATERAL_FILTER = False # Reduce number of lines with bilateral filter
 DOWNLOAD_IMAGES = False # Download each rendered frame automatically (works best in firefox)
@@ -50,6 +51,7 @@ def help():
     print('\t-g\t\tHide the grid in the background of the graph\n')
     print('\t--yes\t\tAgree to EULA without input prompt')
     print('\t--size <widthxheight>\tDimensions for downloaded images (e.g. 3840x2160)')
+    print('\t--format <extension>\tSpecify format when downloading frames: "svg" or "png" (default is "png")')
 
 
 def get_contours(filename, nudge = .33):
@@ -129,13 +131,13 @@ def index():
 @app.route("/calculator")
 def client():
     return render_template('index.html', api_key='dcb31709b452b1cf9dc26972add0fda6', # Development-only API_key. See https://www.desmos.com/api/v1.8/docs/index.html#document-api-keys
-            height=height.value, width=width.value, total_frames=len(os.listdir(FRAME_DIR)), download_images=DOWNLOAD_IMAGES, show_grid=SHOW_GRID, screenshot_size=SCREENSHOT_SIZE)
+            height=height.value, width=width.value, total_frames=len(os.listdir(FRAME_DIR)), download_images=DOWNLOAD_IMAGES, show_grid=SHOW_GRID, screenshot_size=SCREENSHOT_SIZE, screenshot_format=SCREENSHOT_FORMAT)
 
 
 if __name__ == '__main__':
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "hf:e:c:bdlg", ['static', 'block=', 'maxpblock=', 'yes', 'size='])
+        opts, args = getopt.getopt(sys.argv[1:], "hf:e:c:bdlg", ['static', 'block=', 'maxpblock=', 'yes', 'size=', 'format='])
 
     except getopt.GetoptError:
         print('Error: Invalid argument(s)\n')
@@ -170,6 +172,10 @@ if __name__ == '__main__':
 
                 if len(SCREENSHOT_SIZE) != 2:
                     raise ValueError
+            elif opt == '--format':
+                if arg not in ('svg', 'png'):
+                    raise ValueError
+                SCREENSHOT_FORMAT = arg
                 
         frame_latex =  range(len(os.listdir(FRAME_DIR)))
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -108,10 +108,10 @@
                     await changeGraph(response);
 
                     const params = {
-                        mode: 'stretch',
+                        mode: 'contain',
                         mathBounds: { left: 0, bottom: 0, right: {{ width }}, top: {{ height }} },
-                        width: {{ width }},
-                        height: {{ height }},
+                        width: {{ screenshot_size|tojson }}[0] || window.screen.width,
+                        height: {{ screenshot_size|tojson }}[1] || window.screen.height,
                         targetPixelRatio: 1
                     }
                     

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -112,7 +112,8 @@
                         mathBounds: { left: 0, bottom: 0, right: {{ width }}, top: {{ height }} },
                         width: {{ screenshot_size|tojson }}[0] || window.screen.width,
                         height: {{ screenshot_size|tojson }}[1] || window.screen.height,
-                        targetPixelRatio: 1
+                        targetPixelRatio: 1,
+                        format: {{ screenshot_format|tojson }}
                     }
                     
                     function finishRender() {
@@ -144,12 +145,24 @@
         const imgcont = document.createElement('a');
         document.body.appendChild(imgcont);
         async function handleScreenshot(screenshot, frame) {
-            if ({{ download_images|tojson }}) {
-                imgcont.href = screenshot;
-                imgcont.download = 'frame-' + String(frame).padStart(5, '0');
-                imgcont.innerHTML = `<img src= ${screenshot}>`;
-                imgcont.click();
+
+            if (!{{ download_images|tojson }}) {
+                return;
             }
+
+            if ( {{ screenshot_format|tojson }} === 'png' ) {
+                screenshot_uri = screenshot;
+            }
+            else if ( {{ screenshot_format|tojson }} === 'svg' ) {
+                var svg_b64 = window.btoa(screenshot); // encode to base64
+                screenshot_uri = "data:image/svg+xml;base64," + svg_b64;
+            }
+
+            imgcont.href = screenshot_uri;
+            imgcont.download = 'frame-' + String(frame).padStart(5, '0');
+            imgcont.innerHTML = `<img src= ${screenshot_uri}>`;
+            imgcont.click();
+            
         }
    </script>
 </html>


### PR DESCRIPTION
This should give you better looking screenshots.

- There's an option to change the screenshot resolution, by default it will download the images based on your device resolution.
- There's also an option to convert the images to svg which desmos supports, they look nice with bezier curves.

It seems like the graph lines don't scale with the image, they stay at a constant 2.5px.
If the resolution for the screenshot becomes too small, the lines will start to overlap.
If your resolution becomes too high, the lines will appear to get thinner.
It also seems to affect the grid lines.

You can try this out by downloading a screenshot as 1080p "--size 1920x1080" and one as 4k "--size 3840x2160", they'll look different.
I don't think desmos has an option to change this behavior though.
